### PR TITLE
Updating pgf.preamble to be a string so texfig works with more recent version of matplotlib

### DIFF
--- a/texfig.py
+++ b/texfig.py
@@ -11,16 +11,17 @@ from math import sqrt
 default_width = 5.78853 # in inches
 default_ratio = (sqrt(5.0) - 1.0) / 2.0 # golden mean
 
-mpl.rcParams.update({
-    "text.usetex": True,
-    "pgf.texsystem": "xelatex",
-    "pgf.rcfonts": False,
-    "font.family": "serif",
-    "font.serif": [],
-    "font.sans-serif": [],
-    "font.monospace": [],
-    "figure.figsize": [default_width, default_width * default_ratio],
-    "pgf.preamble": [
+mpl.rcParams["text.usetex"] = True
+
+mpl.rcParams["pgf.texsystem"] = "xelatex"
+mpl.rcParams["pgf.rcfonts"] = False
+
+mpl.rcParams["pgf.rcfonts"] = False
+mpl.rcParams["font.family"] = "serif"
+mpl.rcParams["font.sans-serif"] = []
+mpl.rcParams["font.monospace"] = []
+mpl.rcParams["figure.figsize"] = [default_width, default_width * default_ratio]
+mpl.rcParams[ "pgf.preamble"] =  [
         # put LaTeX preamble declarations here
         r"\usepackage[utf8x]{inputenc}",
         r"\usepackage[T1]{fontenc}",
@@ -28,8 +29,7 @@ mpl.rcParams.update({
         r"\newcommand{\vect}[1]{#1}",
         # You can use dummy implementations, since your LaTeX document
         # will render these properly, anyway.
-    ],
-})
+    ]
 
 import matplotlib.pyplot as plt
 

--- a/texfig.py
+++ b/texfig.py
@@ -10,12 +10,8 @@ mpl.use('pgf')
 from math import sqrt
 default_width = 5.78853 # in inches
 default_ratio = (sqrt(5.0) - 1.0) / 2.0 # golden mean
-
 mpl.rcParams["text.usetex"] = True
-
 mpl.rcParams["pgf.texsystem"] = "xelatex"
-mpl.rcParams["pgf.rcfonts"] = False
-
 mpl.rcParams["pgf.rcfonts"] = False
 mpl.rcParams["font.family"] = "serif"
 mpl.rcParams["font.sans-serif"] = []

--- a/texfig.py
+++ b/texfig.py
@@ -21,7 +21,7 @@ mpl.rcParams["font.family"] = "serif"
 mpl.rcParams["font.sans-serif"] = []
 mpl.rcParams["font.monospace"] = []
 mpl.rcParams["figure.figsize"] = [default_width, default_width * default_ratio]
-mpl.rcParams[ "pgf.preamble"] =  [
+mpl.rcParams[ "pgf.preamble"] =  "\n".join([
         # put LaTeX preamble declarations here
         r"\usepackage[utf8x]{inputenc}",
         r"\usepackage[T1]{fontenc}",
@@ -29,7 +29,7 @@ mpl.rcParams[ "pgf.preamble"] =  [
         r"\newcommand{\vect}[1]{#1}",
         # You can use dummy implementations, since your LaTeX document
         # will render these properly, anyway.
-    ]
+    ])
 
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
texfig appears to be broken when using recent versions of matplotlib, for example version 3.7.1

The error you get will be something similar to the following:
```
ValueError: Key pgf.preamble: Could not convert ['\\usepackage[utf8x]{inputenc}', '\\usepackage[T1]{fontenc}', '\\newcommand{\\vect}[1]{#1}'] to str
```

To fix this I have updated pgf.preamble to be a string so texfig works with these more recent versions of matplotlib

I have also updated the way that parameters are changed, to modify properties, as it seems the update method is no longer recommended.
See
https://stackoverflow.com/a/60523330
